### PR TITLE
feat: new custom tab 'Product Add-Ons'

### DIFF
--- a/class-product-fields-admin.php
+++ b/class-product-fields-admin.php
@@ -6,6 +6,8 @@
  * @package Product_Fields_Admin
  */
 
+namespace ProductFieldsAdmin;
+
 defined( 'ABSPATH' ) || exit;
 
 class Init {
@@ -14,7 +16,8 @@ class Init {
 
 	public function __construct() {
 
-		add_action( 'woocommerce_product_options_general_product_data', [ $this, 'register_wc_product_custom_fields' ] );
+		add_action( 'woocommerce_product_data_panels', [ $this, 'register_wc_product_custom_fields' ] );
+		add_filter( 'woocommerce_product_data_tabs', [ $this, 'settings_tabs' ] );
 		add_action( 'woocommerce_process_product_meta', [ $this, 'save_wc_product_custom_fields' ] );
 		add_action( 'woocommerce_before_add_to_cart_button', [ $this, 'display_wc_product_custom_fields' ] );
 		add_filter( 'woocommerce_add_to_cart_validation', [ $this, 'validate_wc_custom_fields' ], 10, 3 );
@@ -29,7 +32,9 @@ class Init {
 	 */
 	public function register_wc_product_custom_fields() {
 		global $woocommerce, $post;
-		echo '<div class="product_custom_field">';
+
+		echo '<div id="product_add_ons" class="panel woocommerce_options_panel hidden">';
+
 		woocommerce_wp_text_input(
 			[
 				'id'          => 'custom_product_text_field',
@@ -50,6 +55,23 @@ class Init {
 		$title   = isset( $_POST['custom_product_text_field'] ) ? $_POST['custom_product_text_field'] : '';
 		$product->update_meta_data( 'custom_product_text_field', sanitize_text_field( $title ) );
 		$product->save();
+	}
+
+	/**
+	 * Creates a custom tab for the custom fields
+	 *
+	 * @param array $tabs Custom Tab.
+	 */
+	public function settings_tabs( $tabs ) {
+
+		$tabs['product_add_ons'] = [
+			'label'    => 'Product Add-Ons',
+			'target'   => 'product_add_ons',
+			'class'    => [ 'show_if_simple' ],
+			'priority' => 21,
+		];
+		return $tabs;
+
 	}
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     }
   ],
   "support": {
-    "src": "https://github.com/sarahcssiqueira/product-fields-admin",
-    "issues": "https://github.com/sarahcssiqueira/product-fields-admin/issues"
+    "src": "https://github.com/sarahcssiqueira/plugin-product-fields-admin",
+    "issues": "https://github.com/sarahcssiqueira/plugin-product-fields-admin/issues"
   },
   "autoload": {
     "psr-4": {

--- a/product-fields-admin.php
+++ b/product-fields-admin.php
@@ -16,8 +16,9 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Bootstraps the plugin, run after all plugins are loaded.
+ * Bootstraps the plugin.
  */
 require __DIR__ . '/class-product-fields-admin.php';
 
+use ProductFieldsAdmin\Init;
 Init::get_instance();


### PR DESCRIPTION
## Feat

To better organize the new custom product fields, it was created a new tab called **Product Add-Ons**:

To achieve that, the function's **register_wc_product_custom_fields** hook was replaced from `woocommerce_product_options_general_product_data` to `woocommerce_product_data_panels` and a new function **settings_tabs** was created, filtered by `woocommerce_product_data_tabs`.

The 'echo' statements on **register_wc_product_custom_fields** were also replaced accordingly. From `echo '<div class="product_custom_field">'` to `echo '<div id="product_add_ons" class="panel woocommerce_options_panel hidden">';`

## Files 'Namespaced'

Namespaces added to the project

## Minor fix: 

Fixed GitHub repository URL on Composer.json
